### PR TITLE
Remove database-controller from args 

### DIFF
--- a/deployment.yaml
+++ b/deployment.yaml
@@ -91,7 +91,6 @@ spec:
       - name: controller
         image: torchbox/k8s-database-controller:v1.0.0-alpha6
         args:
-        - /database-controller
         - --config=/config/config.yaml
         volumeMounts:
         - name: config


### PR DESCRIPTION
Since the docker image already got the entrypoint set to the binary the first line is not necessary.