### PR TITLE
Change database creation query in postgres

### DIFF
--- a/postgresql.go
+++ b/postgresql.go
@@ -74,10 +74,18 @@ func (cllr *DatabaseController) handleAddPostgresql(db *Database) {
 		return
 	}
 
-	_, err = dbconn.Exec(fmt.Sprintf("CREATE DATABASE \"%s\" OWNER \"%s\" TEMPLATE \"template0\"", dbname, dbname))
+	_, err = dbconn.Exec(fmt.Sprintf("CREATE DATABASE \"%s\" TEMPLATE \"template0\"", dbname))
 	if err != nil {
 		cllr.setError(db, fmt.Sprintf("failed to create database: %v", err))
 		log.Printf("%s/%s: failed to create database: %v\n",
+			db.Namespace, db.Name, err)
+		return
+	}
+
+	_, err = dbconn.Exec(fmt.Sprintf("GRANT ALL ON DATABASE \"%s\" TO \"%s\"", dbname, dbname))
+	if err != nil {
+		cllr.setError(db, fmt.Sprintf("failed to create database: %v", err))
+		log.Printf("%s/%s: failed to grant privileges: %v\n",
 			db.Namespace, db.Name, err)
 		return
 	}


### PR DESCRIPTION
The previous query doesn't work on cloud postgresql instances (ex, Google CloudSQL, Amazon RDS) due some privileges issues. The recommended way is create the database and then provide privileges. More info: https://stackoverflow.com/questions/26684643/error-must-be-member-of-role-when-creating-schema-in-postgresql